### PR TITLE
result AR in join_best_rank since we don't know how to bind yet

### DIFF
--- a/lib/through_hierarchy/associations/has_one.rb
+++ b/lib/through_hierarchy/associations/has_one.rb
@@ -10,10 +10,7 @@ module ThroughHierarchy
       private
 
       def get_joins
-        arel = @associated.join_best_rank
-        result = @model.joins(arel.join_sources).order(arel.orders)
-        arel.constraints.each{|cc| result = result.where(cc)}
-        return result
+        @associated.join_best_rank
       end
 
     end

--- a/lib/through_hierarchy/associations/has_uniq.rb
+++ b/lib/through_hierarchy/associations/has_uniq.rb
@@ -22,10 +22,7 @@ module ThroughHierarchy
       end
 
       def get_joins
-        arel = @associated.join_best_rank(group_by: @uniq)
-        result = @model.joins(arel.join_sources).order(arel.orders)
-        arel.constraints.each{|cc| result = result.where(cc)}
-        return result
+        @associated.join_best_rank(group_by: @uniq)
       end
 
     end


### PR DESCRIPTION
Fix a bug where bind_values were not getting used in `joins_through_hierarchy`
